### PR TITLE
Adopt layout of deRSE'19 conference

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,94 @@
-<html>
-<!-- We are a little headless for now :) -->
-<body>
-Stay tuned for news from un-deRSE23, the deRSE Unconference 2023!
-</body>
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+		
+		<title>de-RSE Unconference 2023 (un-deRSE23)</title>
+		
+		<script type="text/javascript" src="https://de-rse.org/js/jquery-1.11.3.min.js"></script>
+		<script type="text/javascript" src="https://de-rse.org/bootstrap/js/bootstrap.min.js"></script>
+		
+		<!-- Bootstrap core CSS -->
+		<link rel="stylesheet" type="text/css" href="https://de-rse.org/bootstrap/css/bootstrap.min.css">
+		<!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
+		<!--[if lt IE 9]>
+		<script src='https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js'></script>
+		<script src='https://oss.maxcdn.com/respond/1.4.2/respond.min.js'></script>
+		<![endif]-->
+		
+		<style>body { padding-top: 70px; }</style>
+		<link rel="stylesheet" type="text/css" href="https://de-rse.org/css/leaflet.css">
+		<link rel="stylesheet" type="text/css" href="https://de-rse.org/css/MarkerCluster.Default.css">
+		<link rel="stylesheet" type="text/css" href="https://de-rse.org/css/MarkerCluster.css">
+		<link rel="stylesheet" type="text/css" href="https://de-rse.org/css/de-rse.css">
+		
+		<link rel="icon" href="https://de-rse.org/assets/img/site/favicon.ico?" sizes="16x16 24x24 32x32 64x64" type="image/vnd.microsoft.icon">
+
+		<link rel="alternate" href="https://de-rse.org/de/index.html" hreflang="de">
+		<link rel="alternate" href="https://de-rse.org/en/index.html" hreflang="en">
+		<link rel="alternate" type="application/rss+xml" title="de-RSE.org" href="https://de-rse.org/feed.xml">
+
+		<meta name="description" content="">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+  
+		<link rel="canonical" href="https://de-rse.org/unconf2023/">
+	</head>
+
+	<body class="home">
+		<nav class="navbar navbar-default navbar-fixed-top" data-nav-highlight="true">
+			<div class="container container-navbar">
+				<div class="navbar-header">
+					<button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">
+						<span class="icon-bar"></span>
+						<span class="icon-bar"></span>
+						<span class="icon-bar"></span>
+					</button>
+					<a class="navbar-brand navbar-logo" href="https://de-rse.org/index.html"><img src="./index_files/rse.png"></a>
+				</div>
+				<div id="navbar" class="collapse navbar-collapse">
+					<ul class="nav navbar-nav">
+						<li class="navbar-conflink"><a href="https://de-rse.org/de/conf2019/index.html">deRSE Unconference 2023</a></li>
+						<li class="navbar-conflink"><a href="#facts">Facts</a></li>
+						<li class="navbar-conflink dropdown">
+							<a class="nav-link dropdown-toggle" href="https://de-rse.org/de/conf2019/info.html" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Participate ▼</a>
+							<div class="dropdown-menu" aria-labelledby="navbarDropdown">
+								<a class="dropdown-item" href="#volunteering">Volunteering</a>
+								<a class="dropdown-item" href="#venue">Venue</a>
+								<a class="dropdown-item" href="#code-of-conduct">Code of Conduct &amp; Diversity</a>
+							</div>
+						</li>
+						<li class="navbar-conflink dropdown">
+							<a class="nav-link dropdown-toggle" href="https://de-rse.org/de/conf2019/contact-pr.html" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Contact &amp; PR ▼</a>
+							<div class="dropdown-menu" aria-labelledby="navbarDropdown">
+								<a class="dropdown-item" href="#contact">Contact</a>
+							</div>
+						</li>
+					</ul>
+					<!-- ul class="nav navbar-nav pull-right">
+						<li><a href="https://de-rse.org/en/conf2019/">Englisch/English</a></li>
+					</ul -->
+				</div>
+			</div>
+		</nav>
+		
+		<div class="container">
+			<div class="starter-template">
+				<h1 id="un-derse23">deRSE Unconference 2023</h1>
+
+				<h2 id="facts">Facts</h2>
+				<p><strong>What:</strong> First unconference by and for the German Reseach Software Engineering Community</p>
+				<p><strong>Start:</strong> September 12, 2023 - 12:00</p>
+				<p><strong>End:</strong> September 14, 2023 - 15:00</p>
+				<p><strong>Where:</strong> Dornburger Schl&ouml;sser, Jena, Germany</p>
+
+				<br>
+			</div>
+		</div>
+
+		<div class="footer">
+			<a href="https://de-rse.org/de/conf2019/imprint.html">Impressum (legal notice)</a> | 
+			<a href="https://de-rse.org/feed.xml"><img src="https://de-rse.org/assets/img/site/feed-icon.png" alt="Atom 1.0 Feed" style="height: 20px;"></a> | 
+			<span style="position: relative; top: 6px;"><a href="https://twitter.com/RSE_de?ref_src=twsrc%5Etfw" class="twitter-follow-button" data-show-count="false" data-dnt="true" alt="Twitter account">Follow @RSE_de</a><script async="" src="https://platform.twitter.com/widgets.js" charset="utf-8"></script></span>
+		</div>
+	</body>
 </html>


### PR DESCRIPTION
Just the basic layout, not much information yet.

I used a dump of https://de-rse.org/de/conf2019 as template, heavily stripped a lot and added basic meta-data.

Not very nice yet, not very maintainable yet. However, in conjunction with https://github.com/DE-RSE/de-rse.github.io/pull/241 this should give a good first shot.